### PR TITLE
[fix] add live region root check to alert component

### DIFF
--- a/packages/accordion/CHANGELOG.md
+++ b/packages/accordion/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.15](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-accordion@0.0.11...@ciceksepeti/cui-accordion@0.0.15) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-accordion
+
+
+
+
+
 ## [0.0.14](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-accordion@0.0.11...@ciceksepeti/cui-accordion@0.0.14) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-accordion

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-accordion",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "ÇiçekSepeti Accordion Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,8 +20,8 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/alert-dialog/CHANGELOG.md
+++ b/packages/alert-dialog/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-alert-dialog@0.1.1...@ciceksepeti/cui-alert-dialog@0.1.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-alert-dialog
+
+
+
+
+
 ## [0.1.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-alert-dialog@0.1.1...@ciceksepeti/cui-alert-dialog@0.1.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-alert-dialog

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-alert-dialog",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ÇiçekSepeti Alert Dialog Component",
   "author": "ciceksepeti",
   "sideEffects": [
@@ -24,9 +24,9 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-dialog": "0.11.4",
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-dialog": "0.11.5",
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/alert/CHANGELOG.md
+++ b/packages/alert/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-alert@0.11.1...@ciceksepeti/cui-alert@0.11.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-alert
+
+
+
+
+
 ## [0.11.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-alert@0.11.1...@ciceksepeti/cui-alert@0.11.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-alert

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-alert",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "ÇiçekSepeti Accessible Alert Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,9 +20,9 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4",
-    "@ciceksepeti/cui-visually-hidden": "0.1.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5",
+    "@ciceksepeti/cui-visually-hidden": "0.1.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -174,7 +174,7 @@ export const Alert = forwardRef(
     forwardedRef
   ) => {
     const { as, children, type = 'polite', ...rest } = props;
-    
+
     const Component = as || 'div';
     const internalRef = useRef(null);
     const ref = useCombinedRefs(forwardedRef, internalRef);

--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -49,6 +49,15 @@ const liveRegionContainers: LiveRegionElementTypes = {
 };
 
 /**
+ * holds references to created live roots
+ */
+const liveRegionRoots: LiveRegionRoots = {
+  off: null,
+  polite: null,
+  assertive: null
+};
+
+/**
  * creates functions for a created alert
  * @param liveRegionType
  * @returns CloneRef
@@ -108,7 +117,13 @@ const renderAlertsToRegions = () => {
     const regionElements = liveRegionContainerElements[liveRegionType];
 
     if (container) {
-      const root = ReactDOM.createRoot(container as Element);
+      let root = liveRegionRoots[liveRegionType];
+
+      if (!root) {
+        const _root = ReactDOM.createRoot(container as Element);
+        liveRegionRoots[liveRegionType] = _root;
+        root = _root;
+      }
 
       root.render(
         <VisuallyHidden as="div">
@@ -159,7 +174,7 @@ export const Alert = forwardRef(
     forwardedRef
   ) => {
     const { as, children, type = 'polite', ...rest } = props;
-
+    
     const Component = as || 'div';
     const internalRef = useRef(null);
     const ref = useCombinedRefs(forwardedRef, internalRef);
@@ -196,6 +211,10 @@ type LiveRegionElements = {
 
 type LiveRegionElementTypes<T extends HTMLElement = HTMLDivElement> = {
   [key in LiveRegionType]: T | null;
+};
+
+type LiveRegionRoots = {
+  [key in LiveRegionType]: ReactDOM.Root | null;
 };
 
 type LiveRegionKeys = {

--- a/packages/checkbox/CHANGELOG.md
+++ b/packages/checkbox/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.19](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-checkbox@0.0.13...@ciceksepeti/cui-checkbox@0.0.19) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+
+### Bug Fixes
+
+* listbox input search rerender trigger issue fix ([#47](https://github.com/ciceksepetitech/cactus-ui/issues/47)) ([d426f09](https://github.com/ciceksepetitech/cactus-ui/commit/d426f0918db2ef14614ed144b4713e2f80fa73c4))
+
+
+
+
+
 ## [0.0.18](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-checkbox@0.0.13...@ciceksepeti/cui-checkbox@0.0.18) (2024-02-12)
 
 

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-checkbox",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "ÇiçekSepeti Checkbox Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,8 +24,8 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.7](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui@0.11.1...@ciceksepeti/cui@0.11.7) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+
+### Bug Fixes
+
+* listbox input search rerender trigger issue fix ([#47](https://github.com/ciceksepetitech/cactus-ui/issues/47)) ([d426f09](https://github.com/ciceksepetitech/cactus-ui/commit/d426f0918db2ef14614ed144b4713e2f80fa73c4))
+
+
+
+
+
 ## [0.11.6](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui@0.11.1...@ciceksepeti/cui@0.11.6) (2024-02-12)
 
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "description": "ÇiçekSepeti Cactus UI All Packages",
   "author": "cs",
   "main": "dist/src/index.js",
@@ -23,21 +23,21 @@
     "styles.css"
   ],
   "dependencies": {
-    "@ciceksepeti/cui-accordion": "0.0.14",
-    "@ciceksepeti/cui-alert": "0.11.4",
-    "@ciceksepeti/cui-alert-dialog": "0.1.4",
-    "@ciceksepeti/cui-checkbox": "0.0.18",
-    "@ciceksepeti/cui-dialog": "0.11.4",
-    "@ciceksepeti/cui-focus-trap": "0.1.4",
-    "@ciceksepeti/cui-hooks": "0.11.4",
+    "@ciceksepeti/cui-accordion": "0.0.15",
+    "@ciceksepeti/cui-alert": "0.11.5",
+    "@ciceksepeti/cui-alert-dialog": "0.1.5",
+    "@ciceksepeti/cui-checkbox": "0.0.19",
+    "@ciceksepeti/cui-dialog": "0.11.5",
+    "@ciceksepeti/cui-focus-trap": "0.1.5",
+    "@ciceksepeti/cui-hooks": "0.11.5",
     "@ciceksepeti/cui-listbox": "0.0.10",
-    "@ciceksepeti/cui-popover": "0.4.0",
-    "@ciceksepeti/cui-portal": "0.1.4",
-    "@ciceksepeti/cui-radio-group": "0.0.15",
-    "@ciceksepeti/cui-skip-nav": "0.1.4",
-    "@ciceksepeti/cui-tabs": "0.0.15",
-    "@ciceksepeti/cui-utils": "0.11.4",
-    "@ciceksepeti/cui-visually-hidden": "0.1.4"
+    "@ciceksepeti/cui-popover": "0.5.0",
+    "@ciceksepeti/cui-portal": "0.1.5",
+    "@ciceksepeti/cui-radio-group": "0.0.16",
+    "@ciceksepeti/cui-skip-nav": "0.1.5",
+    "@ciceksepeti/cui-tabs": "0.0.16",
+    "@ciceksepeti/cui-utils": "0.11.5",
+    "@ciceksepeti/cui-visually-hidden": "0.1.5"
   },
   "devDependencies": {
     "gulp": "^4.0.2",

--- a/packages/dialog/CHANGELOG.md
+++ b/packages/dialog/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-dialog@0.11.1...@ciceksepeti/cui-dialog@0.11.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-dialog
+
+
+
+
+
 ## [0.11.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-dialog@0.11.1...@ciceksepeti/cui-dialog@0.11.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-dialog

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-dialog",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "ÇiçekSepeti Accessible Dialog Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,11 +24,11 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-focus-trap": "0.1.4",
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-portal": "0.1.4",
-    "@ciceksepeti/cui-utils": "0.11.4",
-    "@ciceksepeti/cui-visually-hidden": "0.1.4",
+    "@ciceksepeti/cui-focus-trap": "0.1.5",
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-portal": "0.1.5",
+    "@ciceksepeti/cui-utils": "0.11.5",
+    "@ciceksepeti/cui-visually-hidden": "0.1.5",
     "react-remove-scroll": "^2.4.3"
   },
   "peerDependencies": {

--- a/packages/focus-trap/CHANGELOG.md
+++ b/packages/focus-trap/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-focus-trap@0.1.1...@ciceksepeti/cui-focus-trap@0.1.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-focus-trap
+
+
+
+
+
 ## [0.1.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-focus-trap@0.1.1...@ciceksepeti/cui-focus-trap@0.1.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-focus-trap

--- a/packages/focus-trap/package.json
+++ b/packages/focus-trap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-focus-trap",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ÇiçekSepeti Focus Trap Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,8 +20,8 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/hooks/CHANGELOG.md
+++ b/packages/hooks/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-hooks@0.11.1...@ciceksepeti/cui-hooks@0.11.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-hooks
+
+
+
+
+
 ## [0.11.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-hooks@0.11.1...@ciceksepeti/cui-hooks@0.11.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-hooks

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-hooks",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "ÇiçekSepeti Component Hooks",
   "author": "cs",
   "main": "dist/src/index.js",
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "repository": {
     "type": "git",

--- a/packages/listbox/CHANGELOG.md
+++ b/packages/listbox/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.20](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-listbox@0.0.14...@ciceksepeti/cui-listbox@0.0.20) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+
+### Bug Fixes
+
+* listbox input search rerender trigger issue fix ([#47](https://github.com/ciceksepetitech/cactus-ui/issues/47)) ([d426f09](https://github.com/ciceksepetitech/cactus-ui/commit/d426f0918db2ef14614ed144b4713e2f80fa73c4))
+
+
+
+
+
 ## [0.0.19](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-listbox@0.0.14...@ciceksepeti/cui-listbox@0.0.19) (2024-02-12)
 
 

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-listbox",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "ÇiçekSepeti Listbox Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,9 +24,9 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-popover": "0.4.0",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-popover": "0.5.0",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/popover/CHANGELOG.md
+++ b/packages/popover/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.5.0](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-popover@0.0.13...@ciceksepeti/cui-popover@0.5.0) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+
+### Features
+
+* popover prevent overflow feature added and storybook webpack config changes ([#49](https://github.com/ciceksepetitech/cactus-ui/issues/49)) ([7b6c01a](https://github.com/ciceksepetitech/cactus-ui/commit/7b6c01ad56ae1ab794b917efa3cc550af5bdd6d0))
+
+
+
+
+
 # [0.4.0](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-popover@0.0.13...@ciceksepeti/cui-popover@0.4.0) (2024-02-12)
 
 

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-popover",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "ÇiçekSepeti Popover Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,9 +20,9 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-portal": "0.1.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-portal": "0.1.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/portal/CHANGELOG.md
+++ b/packages/portal/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-portal@0.1.1...@ciceksepeti/cui-portal@0.1.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-portal
+
+
+
+
+
 ## [0.1.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-portal@0.1.1...@ciceksepeti/cui-portal@0.1.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-portal

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-portal",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ÇiçekSepeti Portal Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,7 +20,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/radio-group/CHANGELOG.md
+++ b/packages/radio-group/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.16](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-radio-group@0.0.12...@ciceksepeti/cui-radio-group@0.0.16) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-radio-group
+
+
+
+
+
 ## [0.0.15](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-radio-group@0.0.12...@ciceksepeti/cui-radio-group@0.0.15) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-radio-group

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-radio-group",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "ÇiçekSepeti Radio Group Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,8 +24,8 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/skip-nav/CHANGELOG.md
+++ b/packages/skip-nav/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-skip-nav@0.1.1...@ciceksepeti/cui-skip-nav@0.1.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-skip-nav
+
+
+
+
+
 ## [0.1.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-skip-nav@0.1.1...@ciceksepeti/cui-skip-nav@0.1.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-skip-nav

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-skip-nav",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ÇiçekSepeti Skip Nav Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/tabs/CHANGELOG.md
+++ b/packages/tabs/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.0.16](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-tabs@0.0.12...@ciceksepeti/cui-tabs@0.0.16) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-tabs
+
+
+
+
+
 ## [0.0.15](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-tabs@0.0.12...@ciceksepeti/cui-tabs@0.0.15) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-tabs

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-tabs",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "ÇiçekSepeti Tabs Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -24,8 +24,8 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-hooks": "0.11.4",
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-hooks": "0.11.5",
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.11.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-utils@0.11.1...@ciceksepeti/cui-utils@0.11.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-utils
+
+
+
+
+
 ## [0.11.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-utils@0.11.1...@ciceksepeti/cui-utils@0.11.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-utils

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-utils",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "ÇiçekSepeti Component Utils",
   "author": "cs",
   "main": "dist/src/index.js",

--- a/packages/visually-hidden/CHANGELOG.md
+++ b/packages/visually-hidden/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.1.5](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-visually-hidden@0.1.1...@ciceksepeti/cui-visually-hidden@0.1.5) (2024-02-13)
+
+
+
+## 0.0.26 (2024-02-12)
+
+**Note:** Version bump only for package @ciceksepeti/cui-visually-hidden
+
+
+
+
+
 ## [0.1.4](https://github.com/ciceksepetitech/cactus-ui/compare/@ciceksepeti/cui-visually-hidden@0.1.1...@ciceksepeti/cui-visually-hidden@0.1.4) (2024-02-12)
 
 **Note:** Version bump only for package @ciceksepeti/cui-visually-hidden

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciceksepeti/cui-visually-hidden",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ÇiçekSepeti Visually Hidden Component",
   "author": "ciceksepeti",
   "main": "dist/src/index.js",
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/ciceksepetitech/cactus-ui.git"
   },
   "dependencies": {
-    "@ciceksepeti/cui-utils": "0.11.4"
+    "@ciceksepeti/cui-utils": "0.11.5"
   },
   "peerDependencies": {
     "react": ">=16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,14 +6254,15 @@ cachedir@2.3.0:
   integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
 
 call-bind@^1.0.0, call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.6.tgz#6c46675fc7a5e9de82d75a233d586c8b7ac0d931"
-  integrity sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.7.tgz#06016599c40c56498c18769d2730be242b6fa3b9"
+  integrity sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==
   dependencies:
+    es-define-property "^1.0.0"
     es-errors "^1.3.0"
     function-bind "^1.1.2"
-    get-intrinsic "^1.2.3"
-    set-function-length "^1.2.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.1"
 
 call-me-maybe@^1.0.1:
   version "1.0.2"
@@ -6324,9 +6325,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001580:
-  version "1.0.30001585"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001585.tgz#0b4e848d84919c783b2a41c13f7de8ce96744401"
-  integrity sha512-yr2BWR1yLXQ8fMpdS/4ZZXpseBgE7o4g41x3a6AJOqZuOi+iE/WdJYAuZ6Y95i4Ohd2Y+9MzIWRR+uGABH4s3Q==
+  version "1.0.30001587"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001587.tgz#a0bce920155fa56a1885a69c74e1163fc34b4881"
+  integrity sha512-HMFNotUmLXn71BQxg8cijvqxnIAofforZOwGsxyXJ0qugTdspUF4sPSJ2vhgprHCB996tIDzEq1ubumPDV8ULA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -7385,12 +7386,12 @@ defaults@^1.0.3:
     clone "^1.0.2"
 
 define-data-property@^1.0.1, define-data-property@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.2.tgz#f3c33b4f0102360cd7c0f5f28700f5678510b63a"
-  integrity sha512-SRtsSqsDbgpJBbW3pABMCOt6rQyeM8s8RiyeSN8jYG8sYmt/kGJejbydttUsnDs1tadr19tvhT4ShwMyoqAm4g==
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.3.tgz#281845e04737d709c2de99e278546189b65d3055"
+  integrity sha512-h3GBouC+RPtNX2N0hHVLo2ZwPYurq8mLmXpOLTsw71gr7lHt5VaI4vVkDUNOfiWmm48JEXe3VM7PmLX45AMmmg==
   dependencies:
     es-errors "^1.3.0"
-    get-intrinsic "^1.2.2"
+    get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.1"
 
@@ -7655,9 +7656,9 @@ dotenv-expand@^5.1.0:
   integrity sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==
 
 dotenv@^16.0.0:
-  version "16.4.2"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.2.tgz#7ca798f89ae2011846bbdbf6470785307754120d"
-  integrity sha512-rZSSFxke7d9nYQ5NeMIwp5PP+f8wXgKNljpOb7KtH6SKW1cEqcXAz9VSJYVLKe7Jhup/gUYOkaeSVyK8GJ+nBg==
+  version "16.4.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.3.tgz#481235ec516c4e47d2612a478482ee36607f70c1"
+  integrity sha512-II98GFrje5psQTSve0E7bnwMFybNLqT8Vu8JIFWRjsE3khyNUm/loZupuy5DVzG2IXf/ysxvrixYOQnM6mjD3A==
 
 dotenv@^8.0.0:
   version "8.6.0"
@@ -7706,9 +7707,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.648:
-  version "1.4.665"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.665.tgz#681700bd590b0e5a3be66e3e2874ce62abcf5da5"
-  integrity sha512-UpyCWObBoD+nSZgOC2ToaIdZB0r9GhqT2WahPKiSki6ckkSuKhQNso8V2PrFcHBMleI/eqbKgVQgVC4Wni4ilw==
+  version "1.4.667"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.667.tgz#2767d998548e5eeeaf8bdaffd67b56796bfbed3d"
+  integrity sha512-66L3pLlWhTNVUhnmSA5+qDM3fwnXsM6KAqE36e2w4KN0g6pkEtlT5bs41FQtQwVwKnfhNBXiWRLPs30HSxd7Kw==
 
 element-resize-detector@^1.2.2:
   version "1.2.4"
@@ -7893,6 +7894,13 @@ es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.0.tgz#c7faefbdff8b2696cf5f46921edfb77cc4ba3845"
+  integrity sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==
+  dependencies:
+    get-intrinsic "^1.2.4"
 
 es-errors@^1.0.0, es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
@@ -9493,11 +9501,11 @@ has-glob@^1.0.0:
     is-glob "^3.0.0"
 
 has-property-descriptors@^1.0.0, has-property-descriptors@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz#52ba30b6c5ec87fd89fa574bc1c39125c6f65340"
-  integrity sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
   dependencies:
-    get-intrinsic "^1.2.2"
+    es-define-property "^1.0.0"
 
 has-proto@^1.0.1:
   version "1.0.1"
@@ -14952,7 +14960,7 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-function-length@^1.2.0:
+set-function-length@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.1.tgz#47cc5945f2c771e2cf261c6737cf9684a2a5e425"
   integrity sha512-j4t6ccc+VsKwYHso+kElc5neZpjtq9EnRICFZtWyBsLojhmeF/ZBd/elqm22WJh/BziDe/SBiOeAt0m2mfLD0g==


### PR DESCRIPTION
I added live region root check to the Alert component to prevent unnecessary calls of ReactDOM.createRoot in renderAlertsToRegions method.

##### First of all:

- [x] Choose a name suits for the implementation
- [x] Prefix your pull request name with [feat], [fix], [refactor], [ci], [chore], [docs], [test], [style], [refactor], [perf], [build] or [revert]
- [x] Add description about the pull request
- [ ] Add or edit tests and make sure it covers all the implementation
- [ ] Add or edit Storybook
- [ ] Includes a link to issue if exists
- [ ] Check for Accessibility Pratices [w3](https://www.w3.org/TR/wai-aria-practices-1.1/)

##### What this pull request does?

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Refactors an existing package
- [ ] Updates typescript definations
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

##### When creating a new package:

  - [ ] Follows same structure with other packages
  - [ ] Passes all Accessibility Practices
  - [ ] Base styles in a `style.css` file at the root of `src` folder if needed
