### PR TITLE
[fix]: update tabbable elements on changes to children or attributes

### DIFF
--- a/packages/hooks/src/useFindTabbableElements/index.tsx
+++ b/packages/hooks/src/useFindTabbableElements/index.tsx
@@ -1,5 +1,5 @@
 import { getTabbableElements } from '..';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /**
  * gets tabbable elements inside of passed nodeRef
@@ -13,14 +13,28 @@ export function useFindTabbableElements(node: HTMLElement): {
   const [tabbableElements, setTabbableElements] =
     useState<Array<HTMLElement>>();
 
-  /**
-   * creates node list
-   */
-  useEffect(() => {
+  const updateTabbableElements = useCallback(() => {
     if (!node) return;
     const _tabbableElements = getTabbableElements(node);
     setTabbableElements(_tabbableElements);
   }, [node]);
+
+  /**
+   * creates node list and adds mutation observer to update tabbable elements when there is a change in attributes
+   */
+  useEffect(() => {
+    if (!node) return;
+    updateTabbableElements();
+    const observer = new MutationObserver(updateTabbableElements);
+
+    observer.observe(node, {
+      subtree: true,
+      childList: true,
+      attributeFilter: ['disabled', 'aria-disabled'],
+    });
+
+    return () => observer.disconnect();
+  }, [node, updateTabbableElements]);
 
   return { tabbableElements };
 }

--- a/packages/hooks/src/useFindTabbableElements/index.tsx
+++ b/packages/hooks/src/useFindTabbableElements/index.tsx
@@ -30,7 +30,7 @@ export function useFindTabbableElements(node: HTMLElement): {
     observer.observe(node, {
       subtree: true,
       childList: true,
-      attributeFilter: ['disabled', 'aria-disabled'],
+      attributeFilter: ['disabled'],
     });
 
     return () => observer.disconnect();


### PR DESCRIPTION
### Problem
The current implementation of the `useFindTabbableElements` hook doesn't update the list of tabbable elements after the initial render. This causes elements to stay un-tabbable even if they should be tabbable. 

Here's an example of this problem, the second button never becomes tabbable even if it's not disabled: https://codesandbox.io/p/sandbox/wispy-dew-yj26r7

### Solution
This PR addresses this issue by adding a MutationObserver that updates the tabbable elements list when it notices changes in child list (element added/removed) or when element's disabled attribute changes.

##### First of all:

- [ ] Choose a name suits for the implementation
- [x] Prefix your pull request name with feat, fix, refactor, ci, chore, docs, test, style, refactor, perf, build or revert
- [x] Add description about the pull request
- [ ] Add or edit tests and make sure it covers all the implementation
- [ ] Add or edit Storybook
- [ ] Includes a link to issue if exists
- [ ] Check for Accessibility Pratices [w3](https://www.w3.org/TR/wai-aria-practices-1.1/)

##### What this pull request does?

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Refactors an existing package
- [ ] Updates typescript definations
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

##### When creating a new package:

  - [ ] Follows same structure with other packages
  - [ ] Passes all Accessibility Practices
  - [ ] Base styles in a `style.css` file at the root of `src` folder if needed
